### PR TITLE
Renames project and adds GitHub integration for versioning and metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Spotify Info & Color API (Flask)
+# Spotify Color API
 
-[![GitHub Release](https://img.shields.io/github/v/release/laxe4k/spotify-info-color-api)](https://github.com/laxe4k/spotify-info-color-api/releases)
-[![GitHub Release Date](https://img.shields.io/github/release-date/laxe4k/spotify-info-color-api)](https://github.com/laxe4k/spotify-info-color-api/releases)
-[![GitHub License](https://img.shields.io/github/license/laxe4k/spotify-info-color-api)](https://github.com/laxe4k/spotify-info-color-api/blob/main/LICENSE)
-[![GitHub contributors](https://img.shields.io/github/contributors/laxe4k/spotify-info-color-api)](https://github.com/laxe4k/spotify-info-color-api/graphs/contributors)
-[![GitHub Packages](https://img.shields.io/badge/GitHub%20Packages-ghcr.io-blue)](https://github.com/laxe4k/spotify-info-color-api/pkgs/container/spotify-info-color-api)
-[![GitHub Issues](https://img.shields.io/github/issues/laxe4k/spotify-info-color-api)](https://github.com/laxe4k/spotify-info-color-api/issues)
-[![CI/CD - Docker](https://github.com/laxe4k/spotify-info-color-api/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/laxe4k/spotify-info-color-api/actions/workflows/ci-cd.yml)
+[![GitHub Release](https://img.shields.io/github/v/release/laxe4k/spotify-color-api)](https://github.com/laxe4k/spotify-color-api/releases)
+[![GitHub Release Date](https://img.shields.io/github/release-date/laxe4k/spotify-color-api)](https://github.com/laxe4k/spotify-color-api/releases)
+[![GitHub License](https://img.shields.io/github/license/laxe4k/spotify-color-api)](https://github.com/laxe4k/spotify-color-api/blob/main/LICENSE)
+[![GitHub contributors](https://img.shields.io/github/contributors/laxe4k/spotify-color-api)](https://github.com/laxe4k/spotify-color-api/graphs/contributors)
+[![GitHub Packages](https://img.shields.io/badge/GitHub%20Packages-ghcr.io-blue)](https://github.com/laxe4k/spotify-color-api/pkgs/container/spotify-color-api)
+[![GitHub Issues](https://img.shields.io/github/issues/laxe4k/spotify-color-api)](https://github.com/laxe4k/spotify-color-api/issues)
+[![CI/CD - Docker](https://github.com/laxe4k/spotify-color-api/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/laxe4k/spotify-color-api/actions/workflows/ci-cd.yml)
 
 API Flask avec UI qui affiche la musique Spotify en cours et extrait une couleur dominante « naturelle mais punchy » depuis la pochette.
 Support multi‑utilisateurs (comptes), OAuth Spotify par utilisateur, tokens chiffrés, endpoints JSON simples et déploiement Docker.
@@ -16,7 +16,7 @@ Support multi‑utilisateurs (comptes), OAuth Spotify par utilisateur, tokens ch
 ## 🏗️ Structure
 
 ```
-spotify-info-color-api/
+spotify-color-api/
 ├─ run.py                                     # Entrypoint Flask (HOST/PORT/FLASK_DEBUG via .env)
 ├─ app/
 │  ├─ __init__.py                             # App factory, config, enregistrement des blueprints
@@ -157,8 +157,8 @@ python run.py
 
 ```yaml
 services:
-  spotify-info-color-api:
-    image: ghcr.io/laxe4k/spotify-info-color-api:latest
+  spotify-color-api:
+    image: ghcr.io/laxe4k/spotify-color-api:latest
     container_name: spotify_info_color_api
     ports:
       - "${PORT}:${PORT}"
@@ -326,9 +326,9 @@ Ce projet est distribué sous licence **MIT** - voir [LICENSE](LICENSE) pour les
 ## ⚡ Contribuer
 
 ### Comment contribuer
-- **Issues** : Signalez des bugs ou proposez des améliorations via [GitHub Issues](https://github.com/laxe4k/spotify-info-color-api/issues)
+- **Issues** : Signalez des bugs ou proposez des améliorations via [GitHub Issues](https://github.com/laxe4k/spotify-color-api/issues)
 - **Pull Requests** : Fork le projet, créez une branche feature, et soumettez vos modifications
-- **Discussions** : Partagez vos idées dans les [GitHub Discussions](https://github.com/laxe4k/spotify-info-color-api/discussions)
+- **Discussions** : Partagez vos idées dans les [GitHub Discussions](https://github.com/laxe4k/spotify-color-api/discussions)
 
 ### Idées d'améliorations
 - Algorithmes de couleur alternatifs (palette complète, couleurs complémentaires)

--- a/app/services/github_version_service.py
+++ b/app/services/github_version_service.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""
+Service utilitaire pour récupérer la version depuis les releases GitHub
+et l'année de création du dépôt.
+
+Par défaut, utilise le repo 'laxe4k/spotify-color-api' mais peut être
+surchargé via la variable d'environnement GITHUB_REPO (format: owner/repo).
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from typing import Optional
+
+import requests
+
+
+GITHUB_API_BASE = "https://api.github.com"
+
+
+def _repo_slug() -> str:
+    return os.getenv("GITHUB_REPO", "laxe4k/spotify-color-api")
+
+
+def get_latest_release_version(timeout: float = 2.5) -> Optional[str]:
+    """Retourne la version (tag) de la dernière release GitHub.
+
+    - Strips le préfixe 'v' s'il existe pour n'afficher que 'X.Y.Z'.
+    - Retourne None si introuvable ou en cas d'erreur réseau.
+    """
+    owner_repo = _repo_slug()
+    url = f"{GITHUB_API_BASE}/repos/{owner_repo}/releases/latest"
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "spotify-color-api/1.0",
+    }
+    try:
+        r = requests.get(url, headers=headers, timeout=timeout)
+        if r.status_code != 200:
+            return None
+        data = r.json() or {}
+        tag = (data.get("tag_name") or data.get("name") or "").strip()
+        if not tag:
+            return None
+        # Enlever un éventuel préfixe 'v' (ex: v1.2.3 -> 1.2.3)
+        if tag.lower().startswith("v"):
+            tag = tag[1:]
+        return tag
+    except Exception:
+        return None
+
+
+def get_repo_created_year(timeout: float = 2.5) -> Optional[int]:
+    """Retourne l'année de création du dépôt GitHub.
+
+    Retourne None si indisponible ou en cas d'erreur réseau.
+    """
+    owner_repo = _repo_slug()
+    url = f"{GITHUB_API_BASE}/repos/{owner_repo}"
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "spotify-color-api/1.0",
+    }
+    try:
+        r = requests.get(url, headers=headers, timeout=timeout)
+        if r.status_code != 200:
+            return None
+        data = r.json() or {}
+        created_at = data.get("created_at")
+        if not created_at:
+            return None
+        # created_at example: '2025-08-06T12:34:56Z'
+        try:
+            dt = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+        except Exception:
+            return None
+        return dt.year
+    except Exception:
+        return None
+
+
+def get_repo_owner_login(timeout: float = 2.5) -> Optional[str]:
+    """Retourne le login du propriétaire (owner) du dépôt GitHub.
+
+    Exemple: "laxe4k". Retourne None en cas d'erreur.
+    """
+    owner_repo = _repo_slug()
+    url = f"{GITHUB_API_BASE}/repos/{owner_repo}"
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "spotify-color-api/1.0",
+    }
+    try:
+        r = requests.get(url, headers=headers, timeout=timeout)
+        if r.status_code != 200:
+            return None
+        data = r.json() or {}
+        owner = (data.get("owner") or {}).get("login")
+        if owner and isinstance(owner, str):
+            return owner
+        return None
+    except Exception:
+        return None

--- a/app/static/css/base.css
+++ b/app/static/css/base.css
@@ -484,3 +484,22 @@ a:focus {
   box-shadow: 0 0 0 2px rgba(88, 166, 255, 0.35);
   border-color: #58a6ff;
 }
+
+/* Footer */
+.site-footer {
+  position: sticky;
+  top: 100vh; /* pousse le footer en bas de page */
+  width: 100%;
+  border-top: 1px solid var(--line);
+  background: #0e1116;
+}
+.site-footer .wrap {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 20px;
+  justify-content: center;
+}
+.site-footer .sep {
+  color: var(--line);
+}

--- a/app/views/templates/_footer.html
+++ b/app/views/templates/_footer.html
@@ -1,0 +1,11 @@
+<footer class="site-footer">
+  <div class="wrap">
+    <span class="muted">v{{ APP_VERSION }}</span>
+    <span class="sep">•</span>
+    <span>
+      © {% if CREATED_YEAR == CURRENT_YEAR %} {{ CURRENT_YEAR }} {% else %} {{
+      CREATED_YEAR }} - {{ CURRENT_YEAR }} {% endif %} {{ REPO_OWNER[:1]|upper
+      }}{{ REPO_OWNER[1:] }} - Tous droits réservés
+    </span>
+  </div>
+</footer>

--- a/app/views/templates/callback.html
+++ b/app/views/templates/callback.html
@@ -19,5 +19,6 @@
         </div>
       </div>
     </div>
+    {% include '_footer.html' %}
   </body>
 </html>

--- a/app/views/templates/index.html
+++ b/app/views/templates/index.html
@@ -74,5 +74,6 @@
         </div>
       </div>
     </section>
+    {% include '_footer.html' %}
   </body>
 </html>

--- a/app/views/templates/settings.html
+++ b/app/views/templates/settings.html
@@ -618,5 +618,6 @@
         el.className = "msg hidden";
       }
     </script>
+    {% include '_footer.html' %}
   </body>
 </html>

--- a/app/views/templates/user.html
+++ b/app/views/templates/user.html
@@ -263,5 +263,6 @@
         });
       }
     </script>
+    {% include '_footer.html' %}
   </body>
 </html>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
-  spotify-info-color-api:
-    image: ghcr.io/laxe4k/spotify-info-color-api:latest
+  spotify-color-api:
+    image: ghcr.io/laxe4k/spotify-color-api:latest
     container_name: spotify_info_color_api
     ports:
       - "${PORT}:${PORT}"


### PR DESCRIPTION
Renames the project from `spotify-info-color-api` to `spotify-color-api`:
- Updates repository name references in Docker configurations, documentation, and badges.

Adds GitHub integration to display repository metadata:
- Retrieves the latest release version from GitHub API as the application version.
- Fetches the repository creation year and owner for dynamic copyright information.
- Exposes these details in templates for improved footer usability.

Enhances the template system:
- Introduces a reusable footer with dynamic application and repository metadata.
- Includes the footer in relevant HTML templates to ensure consistency.

Fixes sticky footer styling for better layout alignment.

Provides fallback mechanisms for metadata to ensure resilience:
- Displays default values when GitHub API is unavailable.

Relates to incremental improvements in project branding and metadata accessibility.