### PR TITLE
Renames project to NowPlaying Color API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Spotify Color API
+# NowPlaying Color API
 
-[![GitHub Release](https://img.shields.io/github/v/release/laxe4k/spotify-color-api)](https://github.com/laxe4k/spotify-color-api/releases)
-[![GitHub Release Date](https://img.shields.io/github/release-date/laxe4k/spotify-color-api)](https://github.com/laxe4k/spotify-color-api/releases)
-[![GitHub License](https://img.shields.io/github/license/laxe4k/spotify-color-api)](https://github.com/laxe4k/spotify-color-api/blob/main/LICENSE)
-[![GitHub contributors](https://img.shields.io/github/contributors/laxe4k/spotify-color-api)](https://github.com/laxe4k/spotify-color-api/graphs/contributors)
-[![GitHub Packages](https://img.shields.io/badge/GitHub%20Packages-ghcr.io-blue)](https://github.com/laxe4k/spotify-color-api/pkgs/container/spotify-color-api)
-[![GitHub Issues](https://img.shields.io/github/issues/laxe4k/spotify-color-api)](https://github.com/laxe4k/spotify-color-api/issues)
-[![CI/CD - Docker](https://github.com/laxe4k/spotify-color-api/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/laxe4k/spotify-color-api/actions/workflows/ci-cd.yml)
+[![GitHub Release](https://img.shields.io/github/v/release/laxe4k/nowplaying-color-api)](https://github.com/laxe4k/nowplaying-color-api/releases)
+[![GitHub Release Date](https://img.shields.io/github/release-date/laxe4k/nowplaying-color-api)](https://github.com/laxe4k/nowplaying-color-api/releases)
+[![GitHub License](https://img.shields.io/github/license/laxe4k/nowplaying-color-api)](https://github.com/laxe4k/nowplaying-color-api/blob/main/LICENSE)
+[![GitHub contributors](https://img.shields.io/github/contributors/laxe4k/nowplaying-color-api)](https://github.com/laxe4k/nowplaying-color-api/graphs/contributors)
+[![GitHub Packages](https://img.shields.io/badge/GitHub%20Packages-ghcr.io-blue)](https://github.com/laxe4k/nowplaying-color-api/pkgs/container/nowplaying-color-api)
+[![GitHub Issues](https://img.shields.io/github/issues/laxe4k/nowplaying-color-api)](https://github.com/laxe4k/nowplaying-color-api/issues)
+[![CI/CD - Docker](https://github.com/laxe4k/nowplaying-color-api/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/laxe4k/nowplaying-color-api/actions/workflows/ci-cd.yml)
 
 API Flask avec UI qui affiche la musique Spotify en cours et extrait une couleur dominante « naturelle mais punchy » depuis la pochette.
 Support multi‑utilisateurs (comptes), OAuth Spotify par utilisateur, tokens chiffrés, endpoints JSON simples et déploiement Docker.
@@ -16,7 +16,7 @@ Support multi‑utilisateurs (comptes), OAuth Spotify par utilisateur, tokens ch
 ## 🏗️ Structure
 
 ```
-spotify-color-api/
+nowplaying-color-api/
 ├─ run.py                                     # Entrypoint Flask (HOST/PORT/FLASK_DEBUG via .env)
 ├─ app/
 │  ├─ __init__.py                             # App factory, config, enregistrement des blueprints
@@ -157,9 +157,9 @@ python run.py
 
 ```yaml
 services:
-  spotify-color-api:
-    image: ghcr.io/laxe4k/spotify-color-api:latest
-    container_name: spotify-color-api
+  nowplaying-color-api:
+    image: ghcr.io/laxe4k/nowplaying-color-api:latest
+    container_name: nowplaying-color-api
     ports:
       - "${PORT}:${PORT}"
     environment:
@@ -326,9 +326,9 @@ Ce projet est distribué sous licence **MIT** - voir [LICENSE](LICENSE) pour les
 ## ⚡ Contribuer
 
 ### Comment contribuer
-- **Issues** : Signalez des bugs ou proposez des améliorations via [GitHub Issues](https://github.com/laxe4k/spotify-color-api/issues)
+- **Issues** : Signalez des bugs ou proposez des améliorations via [GitHub Issues](https://github.com/laxe4k/nowplaying-color-api/issues)
 - **Pull Requests** : Fork le projet, créez une branche feature, et soumettez vos modifications
-- **Discussions** : Partagez vos idées dans les [GitHub Discussions](https://github.com/laxe4k/spotify-color-api/discussions)
+- **Discussions** : Partagez vos idées dans les [GitHub Discussions](https://github.com/laxe4k/nowplaying-color-api/discussions)
 
 ### Idées d'améliorations
 - Algorithmes de couleur alternatifs (palette complète, couleurs complémentaires)


### PR DESCRIPTION
Updates the project's name from "Spotify Color API" to "NowPlaying Color API".

This change reflects a broader scope beyond Spotify, allowing the API to potentially support other music platforms in the future.